### PR TITLE
Corrected a french spelling issue : Extentions > Extensions

### DIFF
--- a/fr_FR/extend.php
+++ b/fr_FR/extend.php
@@ -2,7 +2,7 @@
 
 return array(
 
-	'extend' => 'Extentions',
+	'extend' => 'Extensions',
 
 	'fields' => 'Champs personnalisés',
 	'fields_desc' => 'Créer des champs additionnels',


### PR DESCRIPTION
Just fixed the spelling of the french word "Extensions". 